### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 [English description](#chinese-synonym-library)
 
-##汉语同义词库
+## 汉语同义词库
 
-###说明
+### 说明
 
 + 收集自成语词典、互联网、公众.<BR>
 + 广义同义，例如：乐不可支 = 兴奋 = 兴高采烈 = 喜上眉梢
 + 5945组，25400个同义词.<BR>
 + 旨在学习和分享.
 
-###使用
+### 使用
 + 每组词以换行符 ( \r\n ) 分割<BR>
 + 单个词以制表符 ( \t ) 分割<BR>
 + 多义词以数字后缀区分，如:
@@ -17,15 +17,15 @@
 >&nbsp;&nbsp; 不合1	不同	分歧	差别	差异... <BR>
 >&nbsp;&nbsp; 不合2	不对	差池	差错	纰谬...
 
-###贡献
+### 贡献
 感谢 [@kissyid](https://github.com/kissyid), [@bkbncn](https://github.com/bkbncn)的贡献<br>
 感谢 [@QuChao](https://github.com/QuChao)的支持<br>
 [报告新词或错误](https://github.com/g2384/chi-syn/issues/new)
 
-###作者
+### 作者
 [想和作者玩(weibo)](http://www.weibo.com/hileony/)
 
-###更新
+### 更新
 + 2013.11<br>
 > 发布、公开词库(5945组，25400个同义词)
 + 2013.03<br>
@@ -33,9 +33,9 @@
 + 2012<br>
 > 收集、建立词库
 
-##Chinese Synonym Library
+## Chinese Synonym Library
 
-###Intro
+### Intro
 + Collected from the Internet, dictionaries and public.<BR>
 + Vague synonyms: 乐不可支 = 兴奋 = 兴高采烈 = 喜上眉梢
 + 5940 sets, 24550 words.<BR>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
